### PR TITLE
feat: provide a debug email address to get template error reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,13 @@ public function toMailTemplate($notifiable)
 And that's it.
 When `MailTemplateChannel` will receive the notification it will automatically call `send` method from `MailTemplate` facade.
 
+### Mailjet Specifics
+
+Mailjet API allows to set an email to debug templates. When a template error is
+encountered on email sending, Mailjet sends an error report to this mailbox. To
+do so, set the email in `config/mail-template.php`, in key
+`mailjet.debug_email`.
+
 ### Testing
 
 ```bash

--- a/config/mail-template.php
+++ b/config/mail-template.php
@@ -15,6 +15,11 @@ return [
     'mailjet' => [
         'key' => env('MJ_APIKEY_PUBLIC'),
         'secret' => env('MJ_APIKEY_PRIVATE'),
+        // Uncomment to send mailjet template debug email to configured address.
+        // 'debug_email' => [
+        //     'Name' => 'John Doe',
+        //     'Email' => 'john@example.com'
+        // ],
     ],
 
     'mandrill' => [

--- a/src/Drivers/MailjetDriver.php
+++ b/src/Drivers/MailjetDriver.php
@@ -17,6 +17,8 @@ class MailjetDriver implements Driver
     public $client = null;
 
     /** @var array */
+    private $debugEmail = null;
+
     public $message = [];
 
     /**
@@ -32,6 +34,13 @@ class MailjetDriver implements Driver
 
         if (!isset($config['secret'])) {
             throw InvalidConfiguration::invalidCredential('mailjet', 'secret');
+        }
+
+        if (isset($config['debug_email'])) {
+            $this->debugEmail = $config['debug_email'];
+            if (!(isset($this->debugEmail['Name']) && isset($this->debugEmail['Email']))) {
+                throw new InvalidConfiguration('debug_email in mailjet configuration must have "Name" and "Email" keys');
+            }
         }
 
         $this->client = new Client($config['key'], $config['secret'], true, [
@@ -130,6 +139,10 @@ class MailjetDriver implements Driver
      */
     public function send(): array
     {
+        if ($this->debugEmail) {
+            $this->message['TemplateErrorReporting'] = $this->debugEmail;
+        }
+
         $response = $this->client->post(Resources::$Email, [
             'body' => [
                 'Messages' => [


### PR DESCRIPTION
Mailjet API allows to set an email to debug templates. When a template error is
encountered on email sending, Mailjet sends an error report to this mailbox. To
do so, set the email in `config/mail-template.php`, in key
`mailjet.debug_email`.